### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Version 2.0.0
+
+Released on February 26, 2018.
+
+-   Handle task outputs correctly in parallel mode.
+-   Print task durations on task-end.
+-   Expose `runTask` function to manually execute tasks in other tasks.
+-   Fixed error if task-function does not return a `Promise`.
+-   Removed unused "tasks.js" file.
+-   Updated docs.
+
+### BREAKING CHANGES
+
+-   Ordering of task arguments changed. Now: `(reporter, chainValue, arg...)`.
+-   Module-Export of `tasks.js` file changed. Now: `{ tasks: {}, reporter: (message) => void }`.
+
+
 ## Version 1.0.3
 
 Released on February 19, 2018.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 Released on February 26, 2018.
 
--   Handle task outputs correctly in parallel mode.
--   Print task durations on task-end.
--   Expose `runTask` function to manually execute tasks in other tasks.
+-   Task outputs are handled correctly in parallel mode.
+-   Task durations are shown on task-end.
+-   Exposed `runTask` function to manually execute tasks in other tasks.
 -   Fixed error if task-function does not return a `Promise`.
 -   Removed unused "tasks.js" file.
 -   Updated docs.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install node-task-runner
 ```js
 const tasks = {};
 
-tasks.task1 = () => {
+tasks.task1 = (reporter) => {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve("test chain value");
@@ -38,8 +38,8 @@ tasks.task1 = () => {
   });
 };
 
-tasks.task2 = (chainValue, arg1, arg2) => {
-  console.log(`[chainValue: ${chainValue}, arg1: ${arg1}, arg2: ${arg2}]`);
+tasks.task2 = (reporter, chainValue, arg1, arg2) => {
+  reporter(`[chainValue: ${chainValue}, arg1: ${arg1}, arg2: ${arg2}]`);
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve();
@@ -47,19 +47,36 @@ tasks.task2 = (chainValue, arg1, arg2) => {
   });
 };
 
-module.exports = tasks;
+module.exports = {
+  tasks: tasks,
+  reporter: (m) => console.log(m)
+};
 ```
 You have to export all tasks that should be available. The name of the function is used as task name. All tasks should return a Promise. If they do not, the behavior is the same as `Promise.resolve()`.
 
-In sequential mode previously resolved values, are passed to the next task function. This feature is not available in parallel mode. In the above example, "task2" would receive "test chain value" as `chainValue` if "task1" was executed before. If no value was resolved `undefined` is passed.
+The `reporter` function which is passed to all tasks as first argument should be used to emit output to the command line. This is important in parallel mode to avoid mixed up task output. The runner collects all output submitted through the `reporter` function and emits all if a task finishes. In non-parallel mode the output is emitted immediately as `console.log` would do. The `reporter` function can be set with an export in the tasks-file as shown above. `console.log` will be the default-value
+if no reporter is exported.
+
+In sequential mode previously resolved values, are passed to the next task function as second parameter. This feature is not available in parallel mode. In the above example, "task2" would receive "test chain value" as `chainValue` if "task1" was executed before. If no value was resolved `undefined` is passed.
 
 The given task arguments from the cli are passed to all tasks as separate variables.
 
-**Note**: The `chainValue` is always passed as first parameter to the function, followed by optional task arguments.
-
 Messages of this library are colored, if `chalk` is installed.
 
+## Run tasks manually
+```js
+const ntr = require('node-task-runner');
 
+...
+
+tasks.task3 = (reporter) => {
+  return Promise.all([ntr.runTask("task1", true), ntr.runTask("task2", true)]);
+};
+
+...
+```
+You could run other tasks sequentially or parallel from another task too. The second argument indicates if console outputs should be collected and emitted on
+task-end or if they should be printed immediately. Default value is `false`.
 
 [License](https://github.com/code-chris/node-task-runner/blob/master/LICENSE)
 ------

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,73 +2,60 @@
 
 const path = require('path');
 const fs = require('fs');
+const util = require('./util');
 const args = require('./arguments')(process.argv);
-let output = {};
-let chalk;
-try { chalk = require('chalk'); } catch (e) {}
 
-function message(m, color) {
-  console.log(color && chalk && chalk.keyword(color) ? chalk.keyword(color)(m) : m);
+function runTask(name, parallel) {
+  return executeTask(name, undefined, [], parallel, reportFunction);
 }
 
-function reporter(id, reportFunction, message) {
-  if (args.options.parallel) {
-    const a = output[id] || [];
-    a.push(message);
-    output[id] = a;
-  } else {
-    reportFunction(message);
-  }
-}
-
-function printOutput(id, reportFunction) {
-  const a = output[id] || [];
-  a.forEach((m) => reportFunction(m));
-  delete output[id];
-}
-
-function executeTask(name, chainValue, taskArgs, reportFunction) {
+function executeTask(name, chainValue, taskArgs, parallel, reportFunction) {
   const func = taskDefinition.tasks[name];
 
   if (func) {
     const id = Math.random().toString().replace('.', '');
-    message(`Starting task ${name}...`, 'green');
-    return func(reporter.bind(this, id, reportFunction), chainValue, ...taskArgs)
-        .then(() => printOutput(id, reportFunction))
-        .then(() => message(`Finished task ${name}...`, 'green'))
-        .catch((err) => {
-          printOutput(id, reportFunction);
-          return Promise.reject(err);
-        });
+    const start = Date.now();
+    util.message(`Starting task ${name}...`, 'green');
+    return func(util.reporter.bind(util, id, parallel, reportFunction), chainValue, ...taskArgs)
+      .then(() => util.printOutput(id, reportFunction))
+      .then(() => util.message(`Finished task ${name} in [${util.calculateDuration(start)}]...`, 'green'))
+      .catch((err) => {
+        util.printOutput(id, reportFunction);
+        return Promise.reject(err);
+      });
   } else {
-    message(`Task ${name} does not exist!`, 'red');
+    util.message(`Task ${name} does not exist!`, 'red');
     return Promise.resolve();
   }
+}
+
+module.exports = {
+  runTask: runTask
 }
 
 const taskFile = path.resolve(process.cwd(), args.options.file);
 
 if (!fs.existsSync(taskFile)) {
-  message(`Specified task-file [${taskFile}] does not exist!`, 'red');
+  util.message(`Specified task-file [${taskFile}] does not exist!`, 'red');
   process.exit(1);
 }
 
 const taskDefinition = require(taskFile);
-const reportFunction = taskDefinition.reporter || function (m) { console.log(m); };
+const reportFunction = taskDefinition.reporter || console.log;
 
 if (args.tasks.length === 0) {
-  message(`Available tasks:\n- ${Object.keys(taskDefinition.tasks).join('\n- ')}`, 'yellow');
+  util.message(`Available tasks:\n- ${Object.keys(taskDefinition.tasks).join('\n- ')}`, 'yellow');
   process.exit(1);
 }
 
 if (args.options.parallel) {
-  Promise.all(args.tasks.map((name) => executeTask(name, undefined, args.taskArgs, reportFunction)))
+  Promise.all(args.tasks.map((name) => executeTask(name, undefined, args.taskArgs, args.options.parallel, reportFunction)))
          .catch((err) => {
            throw err;
          });
 } else {
   args.tasks.reduce(
-    (current, next) => current.then((chainValue) => executeTask(next, chainValue, args.taskArgs, reportFunction)), 
+    (current, next) => current.then((chainValue) => executeTask(next, chainValue, args.taskArgs, args.options.parallel, reportFunction)), 
     Promise.resolve())
       .catch((err) => {
         throw err;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -63,10 +63,14 @@ if (args.tasks.length === 0) {
 
 if (args.options.parallel) {
   Promise.all(args.tasks.map((name) => executeTask(name, undefined, args.taskArgs, reportFunction)))
-         .catch(() => process.exit(1));
+         .catch((err) => {
+           throw err;
+         });
 } else {
   args.tasks.reduce(
     (current, next) => current.then((chainValue) => executeTask(next, chainValue, args.taskArgs, reportFunction)), 
     Promise.resolve())
-      .catch(() => process.exit(1));
+      .catch((err) => {
+        throw err;
+      });
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,11 +5,11 @@ const fs = require('fs');
 const util = require('./util');
 const args = require('./arguments')(process.argv);
 
-function runTask(name, parallel) {
+const runTask = (name, parallel) => {
   return executeTask(name, undefined, [], parallel, reportFunction);
 }
 
-function executeTask(name, chainValue, taskArgs, parallel, reportFunction) {
+const executeTask = (name, chainValue, taskArgs, parallel, reportFunction) => {
   const func = taskDefinition.tasks[name];
 
   if (func) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const args = require('./arguments')(process.argv);
+let output = {};
 let chalk;
 try { chalk = require('chalk'); } catch (e) {}
 
@@ -10,12 +11,35 @@ function message(m, color) {
   console.log(color && chalk && chalk.keyword(color) ? chalk.keyword(color)(m) : m);
 }
 
-function executeTask(name, chainValue, taskArgs) {
-  const func = taskFunctions[name];
+function reporter(id, reportFunction, message) {
+  if (args.options.parallel) {
+    const a = output[id] || [];
+    a.push(message);
+    output[id] = a;
+  } else {
+    reportFunction(message);
+  }
+}
+
+function printOutput(id, reportFunction) {
+  const a = output[id] || [];
+  a.forEach((m) => reportFunction(m));
+  delete output[id];
+}
+
+function executeTask(name, chainValue, taskArgs, reportFunction) {
+  const func = taskDefinition.tasks[name];
 
   if (func) {
+    const id = Math.random().toString().replace('.', '');
     message(`Starting task ${name}...`, 'green');
-    return func(chainValue, ...taskArgs).then(() => message(`Finished task ${name}...`, 'green'));
+    return func(reporter.bind(this, id, reportFunction), chainValue, ...taskArgs)
+        .then(() => printOutput(id, reportFunction))
+        .then(() => message(`Finished task ${name}...`, 'green'))
+        .catch((err) => {
+          printOutput(id, reportFunction);
+          return Promise.reject(err);
+        });
   } else {
     message(`Task ${name} does not exist!`, 'red');
     return Promise.resolve();
@@ -29,17 +53,20 @@ if (!fs.existsSync(taskFile)) {
   process.exit(1);
 }
 
-const taskFunctions = require(taskFile);
+const taskDefinition = require(taskFile);
+const reportFunction = taskDefinition.reporter || function (m) { console.log(m); };
 
 if (args.tasks.length === 0) {
-  message(`Available tasks:\n- ${Object.keys(taskFunctions).join('\n- ')}`, 'yellow');
+  message(`Available tasks:\n- ${Object.keys(taskDefinition.tasks).join('\n- ')}`, 'yellow');
   process.exit(1);
 }
 
 if (args.options.parallel) {
-  Promise.all(args.tasks.map((name) => executeTask(name, undefined, args.taskArgs)))
+  Promise.all(args.tasks.map((name) => executeTask(name, undefined, args.taskArgs, reportFunction)))
          .catch(() => process.exit(1));
 } else {
-  args.tasks.reduce((current, next) => current.then((chainValue) => executeTask(next, chainValue, args.taskArgs)), Promise.resolve())
+  args.tasks.reduce(
+    (current, next) => current.then((chainValue) => executeTask(next, chainValue, args.taskArgs, reportFunction)), 
+    Promise.resolve())
       .catch(() => process.exit(1));
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ const executeTask = (name, chainValue, taskArgs, parallel, reportFunction) => {
     const id = Math.random().toString().replace('.', '');
     const start = Date.now();
     util.message(`Starting task ${name}...`, 'green');
-    return func(util.reporter.bind(util, id, parallel, reportFunction), chainValue, ...taskArgs)
+    return (func(util.reporter.bind(util, id, parallel, reportFunction), chainValue, ...taskArgs) || Promise.resolve())
       .then(() => util.printOutput(id, reportFunction))
       .then(() => util.message(`Finished task ${name} in [${util.calculateDuration(start)}]...`, 'green'))
       .catch((err) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,11 +2,11 @@ let output = {};
 let chalk;
 try { chalk = require('chalk'); } catch (e) { }
 
-function message(m, color) {
+const message = (m, color) => {
   console.log(color && chalk && chalk.keyword(color) ? chalk.keyword(color)(m) : m);
 }
 
-function reporter(id, parallel, reportFunction, message) {
+const reporter = (id, parallel, reportFunction, message) => {
   if (parallel) {
     const a = output[id] || [];
     a.push(message);
@@ -16,13 +16,13 @@ function reporter(id, parallel, reportFunction, message) {
   }
 }
 
-function printOutput(id, reportFunction) {
+const printOutput = (id, reportFunction) => {
   const a = output[id] || [];
   a.forEach((m) => reportFunction(m));
   delete output[id];
 }
 
-function calculateDuration(start) {
+const calculateDuration = (start) => {
   const duration = Date.now() - start;
   let seconds = duration / 1000;
   let minutes = Math.floor(duration / 1000 / 60);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,50 @@
+let output = {};
+let chalk;
+try { chalk = require('chalk'); } catch (e) { }
+
+function message(m, color) {
+  console.log(color && chalk && chalk.keyword(color) ? chalk.keyword(color)(m) : m);
+}
+
+function reporter(id, parallel, reportFunction, message) {
+  if (parallel) {
+    const a = output[id] || [];
+    a.push(message);
+    output[id] = a;
+  } else {
+    reportFunction(message);
+  }
+}
+
+function printOutput(id, reportFunction) {
+  const a = output[id] || [];
+  a.forEach((m) => reportFunction(m));
+  delete output[id];
+}
+
+function calculateDuration(start) {
+  const duration = Date.now() - start;
+  let seconds = duration / 1000;
+  let minutes = Math.floor(duration / 1000 / 60);
+  const hours = Math.floor(duration / 1000 / 60 / 60);
+
+  if (seconds >= 60) {
+    if (minutes >= 60) {
+      minutes = Math.floor(minutes - hours * 60);
+      seconds = (seconds - hours * 60 * 60 - minutes * 60).toFixed(2);
+      return `${hours} hrs ${minutes} min ${seconds} sec`;
+    } else {
+      seconds = (seconds - minutes * 60).toFixed(2);
+      return `${minutes} min ${seconds} sec`;
+    }
+  } else {
+    return `${seconds.toFixed(2)} sec`;
+  }
+}
+
+module.exports = {
+  message: message,
+  reporter: reporter,
+  printOutput: printOutput,
+  calculateDuration: calculateDuration
+}


### PR DESCRIPTION
-   Task outputs are handled correctly in parallel mode.
-   Task durations are shown on task-end.
-   Exposed `runTask` function to manually execute tasks in other tasks.
-   Fixed error if task-function does not return a `Promise`.
-   Removed unused "tasks.js" file.
-   Updated docs.

### BREAKING CHANGES

-   Ordering of task arguments changed. Now: `(reporter, chainValue, arg...)`.
-   Module-Export of `tasks.js` file changed. Now: `{ tasks: {}, reporter: (message) => void }`.